### PR TITLE
Add cost warning to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ to Heroku.  It is based of Keycloak's official docker image with some slight mod
 Heroku variable for `PORT` and `DATABASE_URL` properly.
 
 The deployment will be made with a single Performance-M dyno (it won't run very well in smaller dynos
-due to Java's memory hunger) with a free Postgres database attached.
+due to Java's memory hunger - note that a single Performance-M dyno currently costs $250 / mo.  as of Septemeber 2020) with a free Postgres database attached.
 
 [![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 


### PR DESCRIPTION
I was pretty shocked after deploying to see $250 / month cost on the dyno. Probably not an issue for a real company, but I just wanted to check Keycloak out, and this is _so easy_ it made more sense to me than cloning and running locally. 

But yeah, $250 / mo is a lot, and the heroku deploy button process doesn't make it so clear what the cost is IMO.

So i thought we might add a warning 🤷‍♂️ 